### PR TITLE
Refactor release workflow to use lean-release-tag action

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -8,61 +8,16 @@ on:
       - 'lean-toolchain'
 
 jobs:
-  create_release:
+  lean-release-tag:
+    name: Add Lean release tag
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: write
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 2  # Fetch the last two commits for comparison
-
-      - name: Check if lean-toolchain has changed
-        id: check_file_change
-        run: |
-          # Check if the lean-toolchain file was modified in the last commit
-          if git diff --name-only HEAD~1 HEAD | grep -q "^lean-toolchain$"; then
-            echo "CHANGED=true" >> $GITHUB_ENV
-          else
-            echo "CHANGED=false" >> $GITHUB_ENV
-          fi
-
-      - name: Exit if lean-toolchain did not change
-        if: env.CHANGED != 'true'
-        run: echo "No changes in lean-toolchain. Skipping release."
-
-      - name: Read Lean version from lean-toolchain
-        if: env.CHANGED == 'true'
-        id: get_version
-        run: |
-          # Extract the version from the lean-toolchain file (everything after the colon)
-          LEAN_VERSION=$(cut -d ':' -f2 < lean-toolchain | tr -d '[:space:]')
-          echo "tag_name=${LEAN_VERSION}" >> $GITHUB_ENV
-
-      - name: Create Git tag
-        if: env.CHANGED == 'true'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a ${{ env.tag_name }} -m "Release ${{ env.tag_name }}"
-          git push origin ${{ env.tag_name }}
-
-      - name: Create GitHub Release
-        if: env.CHANGED == 'true'
-        uses: actions/github-script@v7
-        env:
-            tag_name: ${{ env.tag_name }}
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          script: |
-            const tagName = process.env.tag_name;
-            const releaseName = `${tagName}`;
-            await github.rest.repos.createRelease({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              tag_name: tagName,
-              name: releaseName,
-              body: `Automated release for Lean version ${tagName}`,
-              draft: false,
-              prerelease: false
-            });
+    - name: lean-release-tag action
+      uses: leanprover-community/lean-release-tag@0a978e45247f1ef211cd9d7f99d0dbd87638a70a # 2025-05-22
+      with:
+        before: ${{ github.event.before }}
+        after: ${{ github.event.after }}
+        do-release: true
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Replaces the custom shell script and GitHub Script steps for tagging and releasing Lean versions with the new `leanprover-community/lean-release-tag` action.